### PR TITLE
Add support for restart, devices, capabilities.

### DIFF
--- a/runlike.py
+++ b/runlike.py
@@ -40,10 +40,11 @@ class Inspector(object):
             for val in values:
                 self.options.append('--%s="%s"' % (option, val))
 
-
     def parse_ports(self):
-        ports = self.get_fact("NetworkSettings.Ports")
-        if ports is not None:
+        ports = self.get_fact("NetworkSettings.Ports") or {}
+        ports.update(self.get_fact("HostConfig.PortBindings") or {})
+
+        if ports:
             for container_port_and_protocol, options in ports.items():
                 if options is not None:
                     host_ip = options[0]["HostIp"]


### PR DESCRIPTION
Adds support for the following flags:

--restart
--cap-add
--cap-remove
--device

I didn't add anything here specific to testing as it seems there's just a single integration test; to be able to test every possible combination for new flags I'd add a real unit test suite with specific JSON bits as fixtures, but wasn't sure if you're into that.